### PR TITLE
Fix LearningSwitch13 to use FDB

### DIFF
--- a/lib/learning_switch13.rb
+++ b/lib/learning_switch13.rb
@@ -1,34 +1,73 @@
+require 'fdb'
+
 # An OpenFlow controller that emulates a layer-2 switch.
 class LearningSwitch13 < Trema::Controller
+  timer_event :age_fdb, interval: 5.sec
+
   INGRESS_FILTERING_TABLE_ID = 0
   FORWARDING_TABLE_ID = 1
 
   AGING_TIME = 180
 
   def start(_args)
+    @fdb = FDB.new
     logger.info "#{name} started."
   end
 
   def switch_ready(datapath_id)
-    add_multicast_mac_drop_flow_entry datapath_id
-    add_default_forwarding_flow_entry datapath_id
-    add_default_flooding_flow_entry datapath_id
+    add_multicast_mac_drop_flow_entry(datapath_id)
+    add_ipv6_multicast_mac_drop_flow_entry(datapath_id)
+    add_default_broadcast_flow_entry(datapath_id)
+    add_default_flooding_flow_entry(datapath_id)
+    add_default_forwarding_flow_entry(datapath_id)
   end
 
-  def packet_in(datapath_id, message)
-    add_forwarding_flow_entry(datapath_id, message)
+  def packet_in(_datapath_id, message)
+    @fdb.learn(message.source_mac, message.in_port)
+    add_forwarding_flow_and_packet_out(message)
+  end
+
+  def age_fdb
+    @fdb.age
   end
 
   private
 
-  def add_forwarding_flow_entry(datapath_id, message)
+  def add_forwarding_flow_and_packet_out(message)
+    port_no = @fdb.lookup(message.destination_mac)
+    add_forwarding_flow_entry(message, port_no) if port_no
+    packet_out(message, port_no || :flood)
+  end
+
+  def add_forwarding_flow_entry(message, port_no)
     send_flow_mod_add(
-      datapath_id,
+      message.datapath_id,
       table_id: FORWARDING_TABLE_ID,
       idle_timeout: AGING_TIME,
       priority: 2,
-      match: Match.new(ether_destination_address: message.source_mac),
-      instructions: Apply.new(SendOutPort.new(message.in_port))
+      match: Match.new(in_port: message.in_port,
+                       ether_destination_address: message.destination_mac,
+                       ether_source_address: message.source_mac),
+      instructions: Apply.new(SendOutPort.new(port_no))
+    )
+  end
+
+  def packet_out(message, port_no)
+    send_packet_out(
+      message.datapath_id,
+      packet_in: message,
+      actions: SendOutPort.new(port_no)
+    )
+  end
+
+  def add_default_broadcast_flow_entry(datapath_id)
+    send_flow_mod_add(
+      datapath_id,
+      table_id: FORWARDING_TABLE_ID,
+      idle_timeout: 0,
+      priority: 3,
+      match: Match.new(ether_destination_address: 'ff:ff:ff:ff:ff:ff'),
+      instructions: Apply.new(SendOutPort.new(:flood))
     )
   end
 
@@ -39,8 +78,7 @@ class LearningSwitch13 < Trema::Controller
       idle_timeout: 0,
       priority: 1,
       match: Match.new,
-      instructions: Apply.new([SendOutPort.new(:controller),
-                               SendOutPort.new(:flood)])
+      instructions: Apply.new(SendOutPort.new(:controller))
     )
   end
 
@@ -50,8 +88,19 @@ class LearningSwitch13 < Trema::Controller
       table_id: INGRESS_FILTERING_TABLE_ID,
       idle_timeout: 0,
       priority: 2,
-      match: Match.new(ether_destination_address: '01:00:5e:00:00:00',
-                       ether_destination_address_mask: 'ff:ff:ff:00:00:00')
+      match: Match.new(ether_destination_address: '01:00:00:00:00:00',
+                       ether_destination_address_mask: 'ff:00:00:00:00:00')
+    )
+  end
+
+  def add_ipv6_multicast_mac_drop_flow_entry(datapath_id)
+    send_flow_mod_add(
+      datapath_id,
+      table_id: INGRESS_FILTERING_TABLE_ID,
+      idle_timeout: 0,
+      priority: 2,
+      match: Match.new(ether_destination_address: '33:33:00:00:00:00',
+                       ether_destination_address_mask: 'ff:ff:00:00:00:00')
     )
   end
 


### PR DESCRIPTION
- 送信先multicast dropルールのmatch field変更(他のマルチキャストアドレスも含まれるようにした)
- 送信先ipv6 multicastのdropルール追加
- 送信先ブロードキャストのfloodルール追加
- unicast のエントリを入力ポート、送信先、送信元のタプルに変更
- FDBを使うように修正
- packet_out するように修正

初期状態

``` bash
$ ovs-ofctl dump-flows brlsw -OOpenFlow13
OFPST_FLOW reply (OF1.3) (xid=0x2):
 cookie=0x0, duration=1.433s, table=0, n_packets=0, n_bytes=0, priority=2,dl_dst=01:00:00:00:00:00/ff:00:00:00:00:00 actions=drop
 cookie=0x0, duration=1.395s, table=0, n_packets=1, n_bytes=70, priority=2,dl_dst=33:33:00:00:00:00/ff:ff:00:00:00:00 actions=drop
 cookie=0x0, duration=1.375s, table=0, n_packets=0, n_bytes=0, priority=1 actions=goto_table:1
 cookie=0x0, duration=1.395s, table=1, n_packets=0, n_bytes=0, priority=3,dl_dst=ff:ff:ff:ff:ff:ff actions=FLOOD
 cookie=0x0, duration=1.386s, table=1, n_packets=0, n_bytes=0, priority=1 actions=CONTROLLER:65535
```

host1 <-> host2 通信後

``` bash
$  ovs-ofctl dump-flows brlsw -OOpenFlow13
OFPST_FLOW reply (OF1.3) (xid=0x2):
 cookie=0x0, duration=49.605s, table=0, n_packets=0, n_bytes=0, priority=2,dl_dst=01:00:00:00:00:00/ff:00:00:00:00:00 actions=drop
 cookie=0x0, duration=49.567s, table=0, n_packets=45, n_bytes=6899, priority=2,dl_dst=33:33:00:00:00:00/ff:ff:00:00:00:00 actions=drop
 cookie=0x0, duration=49.548s, table=0, n_packets=42, n_bytes=5364, priority=1 actions=goto_table:1
 cookie=0x0, duration=49.568s, table=1, n_packets=12, n_bytes=4104, priority=3,dl_dst=ff:ff:ff:ff:ff:ff actions=FLOOD
 cookie=0x0, duration=26.083s, table=1, n_packets=9, n_bytes=378, idle_timeout=180, priority=2,dl_src=53:ac:a4:a8:3a:69,dl_dst=bb:0e:51:fd:7c:67 actions=output:1
 cookie=0x0, duration=6.179s, table=1, n_packets=9, n_bytes=378, idle_timeout=180, priority=2,dl_src=bb:0e:51:fd:7c:67,dl_dst=53:ac:a4:a8:3a:69 actions=output:2
 cookie=0x0, duration=49.558s, table=1, n_packets=12, n_bytes=504, priority=1 actions=CONTROLLER:65535
```
